### PR TITLE
Track: MikeRogers0:feature/use-site-builder-class

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,5 +19,5 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 gem "bridgetown", "~> 0.16.0"
 
 group :bridgetown_plugins do
-  gem "bridgetown-inline-svg", "~> 1.1.0"
+  gem "bridgetown-inline-svg", "~> 1.1.0", github: "MikeRogers0/bridgetown-inline-svg", branch: "feature/use-site-builder-class"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,12 @@
+GIT
+  remote: https://github.com/MikeRogers0/bridgetown-inline-svg.git
+  revision: e71882e49cb6e9aa2d14d5698eafee1fd1541e7d
+  branch: feature/use-site-builder-class
+  specs:
+    bridgetown-inline-svg (1.1.0)
+      bridgetown (>= 0.15, < 2.0)
+      svg_optimizer (~> 0.2.5)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -37,9 +46,6 @@ GEM
       terminal-table (~> 1.8)
       thor (~> 1.0)
       tilt (~> 2.0)
-    bridgetown-inline-svg (1.1.0)
-      bridgetown (>= 0.15, < 2.0)
-      svg_optimizer (~> 0.2.5)
     bridgetown-paginate (0.16.0)
       bridgetown-core (= 0.16.0)
     colorator (1.1.0)
@@ -96,7 +102,7 @@ PLATFORMS
 
 DEPENDENCIES
   bridgetown (~> 0.16.0)
-  bridgetown-inline-svg (~> 1.1.0)
+  bridgetown-inline-svg (~> 1.1.0)!
 
 BUNDLED WITH
    2.1.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/MikeRogers0/bridgetown-inline-svg.git
-  revision: e71882e49cb6e9aa2d14d5698eafee1fd1541e7d
+  revision: 040017c4ea454e142da78b1867cb831864a6d670
   branch: feature/use-site-builder-class
   specs:
     bridgetown-inline-svg (1.1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/MikeRogers0/bridgetown-inline-svg.git
-  revision: 040017c4ea454e142da78b1867cb831864a6d670
+  revision: e118a9b8404d73ab8cfe834fdb6634673011221f
   branch: feature/use-site-builder-class
   specs:
     bridgetown-inline-svg (1.1.0)


### PR DESCRIPTION
This updates the gem to track the branch used in https://github.com/andrewmcodes/bridgetown-inline-svg/pull/6

It should give us a preview of the changes so we know what to expect.

One the PR in the other repo is merged, we can close this PR.

# Preview:

![image](https://user-images.githubusercontent.com/325384/88851985-7fcbcc80-d1e5-11ea-8e7b-fc70fd12876c.png)
